### PR TITLE
Refine comments and task descriptions to decrease the chance of error…

### DIFF
--- a/homework02/homework-part2-transformers.ipynb
+++ b/homework02/homework-part2-transformers.ipynb
@@ -226,10 +226,11 @@
     "        # 2. split the result of step 1 on three equal parts of size self.embed_dim: query, key, value\n",
     "        # 3. compute scaled dot-product attention for different heads in loop. \n",
     "        #    i-th head will work on query[:, :, i*head_dim: (i+1)*head_dim], \n",
-    "        #    key[:, :, i*head_dim: (i+1)*head_dim], value[:, :, i*head_dim: (i+1)*head_dim]\n",
-    "        # 4. apply dropout for each head result\n",
-    "        # 5. concat all results\n",
-    "        # 6. apply self.out_proj to the result of step 5\n",
+    "        #       key[:, :, i*head_dim: (i+1)*head_dim] and value[:, :, i*head_dim: (i+1)*head_dim]\n",
+    "        #    important: apply dropout to attention maps _after_ softmax, but _before_ multiplication by values.\n",
+    "        #    it follows original implementation and corresponds to dropping out tokens.\n",
+    "        # 4. concat all results\n",
+    "        # 5. apply self.out_proj to the result of step 5\n",
     "\n",
     "        raise NotImplementedError\n",
     "        return result"
@@ -308,11 +309,13 @@
    "metadata": {},
    "source": [
     "Then implement `get_lr()` method. It should work as following:\n",
-    "1. If `self.last_epoch` is in `[0, self.warmup_epochs)`, then scheduler is in warm-up mode and learning rate should lineary increase during epochs from `self.warmup_lr_init` to `self.base_lrs` (which is the original learning rate of optimizer)\n",
-    "2. If `self.last_epoch` is equal to `self.warmup_epochs`, then just return `self.base_lrs`.\n",
-    "3. If `self.last_epoch - self.warmup_epochs` is not divisible by `self.step_size` then just return the previous learning rate which is available through `[group['lr'] for group in self.optimizer.param_groups]`\n",
-    "4. If `self.last_epoch - self.warmup_epochs` is divisible by `self.step_size` and the current learning rate multiplied by `self.gamma` is not less then self.min_lr, then multiply it and return the new value.\n",
-    "5. Otherwise just return the last learning rate"
+    "1. If `self.last_epoch` is in `[0, self.warmup_epochs]`, scheduler is in warm-up mode and learning rates for each parameter group should lineary increase during epochs from `self.warmup_lr_init` to `self.base_lrs` (which are the original learning rates)\n",
+    "\n",
+    "2. Else if `self.last_epoch - self.warmup_epochs` is not divisible by `self.step_size`, return the previous learning rates which are available through `[group['lr'] for group in self.optimizer.param_groups]`\n",
+    "\n",
+    "3. Else if `self.last_epoch - self.warmup_epochs` is divisible by `self.step_size` and current learning rates multiplied by `self.gamma` are not less then `self.min_lr`, then multiply them and return new values.\n",
+    "\n",
+    "4. Otherwise return the last learning rates."
    ]
   },
   {
@@ -520,7 +523,7 @@
     "def create_mlp(embedding_dim, mlp_size, dropout_rate):\n",
     "    return nn.Sequential(\n",
     "        # YOUR CODE: Linear + GELU + Dropout + Linear + Dropout\n",
-    "        nn.Linear(..\n",
+    "        nn.Linear(...)\n",
     "    )"
    ]
   },
@@ -540,11 +543,14 @@
     "            return x\n",
     "        keep_prob = 1 - self.drop_prob\n",
     "        shape = (x.shape[0],) + (1,) * (x.ndim - 1)  # work with diff dim tensors, not just 2D ConvNets\n",
-    "        # YOUR CODE: generate random tensor, binarize it, cast to x.dtype, multiply x by the mask, \n",
-    "        # devide the result on keep_prob\n",
+    "        # YOUR CODE: \n",
+    "        # generate random tensor, binarize it, cast to x.dtype, multiply x by the mask, divide the result on keep_prob\n",
     "        random_tensor = torch.rand(...)\n",
     "        output = ...\n",
-    "        return output"
+    "        return output\n",
+    "\n",
+    "# it is also highly recommended to write some simple test to ensure,\n",
+    "# that this layer indeed nullifies input with probability `drop_prob`"
    ]
   },
   {
@@ -559,7 +565,7 @@
     "        super().__init__()\n",
     "        # YOUR CODE\n",
     "        self.attention_pre_norm = ...\n",
-    "        self.attention = torch.nn.MultiheadAttention(...)\n",
+    "        self.attention = torch.nn.MultiheadAttention(...)       # Do not forget to set `batch_first` parameter\n",
     "        self.attention_output_dropout = nn.Dropout(dropout)\n",
     "\n",
     "        self.mlp_pre_norm = ...\n",
@@ -717,7 +723,7 @@
     "        loss.backward()\n",
     "        opt.step()\n",
     "        train_loss.append(loss.data.numpy())\n",
-    "    print (scheduler.get_last_lr())\n",
+    "    print(scheduler.get_last_lr())\n",
     "    scheduler.step()\n",
     "        \n",
     "    # And a full pass over the validation data:\n",


### PR DESCRIPTION
…s and misunderstanding

Concretely:
- Specify where to put dropout in self-attention
- Refine scheduler description to reduce the amount of cases and hint that there are possibly many parameter groups
- Add an advice to test DropPath implementation
- Add a reminder about `batch_first` parameter in nn.MultiheadAttention